### PR TITLE
Revert "Bump loader-utils from 1.4.0 to 1.4.2"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16287,13 +16287,13 @@ __metadata:
   linkType: hard
 
 "loader-utils@npm:^1.2.3, loader-utils@npm:^1.4.0":
-  version: 1.4.2
-  resolution: "loader-utils@npm:1.4.2"
+  version: 1.4.0
+  resolution: "loader-utils@npm:1.4.0"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
     json5: ^1.0.1
-  checksum: eb6fb622efc0ffd1abdf68a2022f9eac62bef8ec599cf8adb75e94d1d338381780be6278534170e99edc03380a6d29bc7eb1563c89ce17c5fed3a0b17f1ad804
+  checksum: d150b15e7a42ac47d935c8b484b79e44ff6ab4c75df7cc4cb9093350cf014ec0b17bdb60c5d6f91a37b8b218bd63b973e263c65944f58ca2573e402b9a27e717
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts lowsky/gh-dashboard-relay#2179