### PR TITLE
Potential fix for code scanning alert no. 2: Server-side URL redirect

### DIFF
--- a/pages/api/auth/callback.ts
+++ b/pages/api/auth/callback.ts
@@ -1,5 +1,21 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+function isSafeRedirectTarget(target: string | string[] | undefined): target is string {
+    if (typeof target !== 'string') {
+        return false;
+    }
+    const trimmed = target.trim();
+    // Only allow absolute paths within this application.
+    if (!trimmed.startsWith('/')) {
+        return false;
+    }
+    // Disallow protocol-relative and external URLs.
+    if (trimmed.startsWith('//') || trimmed.includes('://')) {
+        return false;
+    }
+    return true;
+}
+
 export default async function callback(req: NextApiRequest, res: NextApiResponse) {
     const code = req.query.code as string;
     const client_id = process.env.GH_BASIC_CLIENT_ID;
@@ -25,11 +41,12 @@ export default async function callback(req: NextApiRequest, res: NextApiResponse
 
         if (access_token) {
             res.setHeader('Set-Cookie', `access_token=${access_token}; HttpOnly; Path=/`);
-            const original_url = req.query.original_url as string;
+            const original_url = req.query.original_url;
 
             console.log({ original_url });
 
-            res.redirect(original_url ?? '/');
+            const redirectTarget = isSafeRedirectTarget(original_url) ? original_url.trim() : '/';
+            res.redirect(redirectTarget);
             return;
         }
         res.redirect('/error?no-token-in-payload');


### PR DESCRIPTION
Potential fix for [https://github.com/lowsky/gh-dashboard-relay/security/code-scanning/2](https://github.com/lowsky/gh-dashboard-relay/security/code-scanning/2)

To fix the problem, the redirect target derived from `req.query.original_url` must be constrained so it cannot send users to arbitrary external URLs. The common approaches are: (1) allow only a whitelist of known-good redirect targets (for example, a small set of route names or IDs), or (2) ensure the redirect remains within the same origin and preferably uses only relative paths.

Given the existing behavior (redirect back to an “original URL” after login) and the goal of not changing functionality more than necessary, the best fix here is to validate `original_url` as an internal URL. In this context, we can treat any value that is not a safe, application-internal path as invalid and fall back to `/`. A straightforward, dependency-free way is to restrict `original_url` to relative paths that: (a) start with `/`, (b) do not contain protocol indicators like `://`, and (c) do not start with `//` (which can be interpreted as protocol-relative URLs). This keeps redirects on the same site while preserving the existing UX for legitimate internal paths.

Concretely in `pages/api/auth/callback.ts`:

- Add a small helper function `isSafeRedirectTarget(target: string | undefined): boolean` near the top or within this file. This function should:
  - Return `false` if `target` is falsy or not a string.
  - Trim whitespace.
  - Ensure `target` starts with `/`.
  - Reject any value containing `://`.
  - Reject values starting with `//`.
- Replace the existing `res.redirect(original_url ?? '/');` with logic that calls `isSafeRedirectTarget(original_url)` and redirects to `original_url` only if it passes validation, otherwise redirecting to `'/'`.

No new imports are required, and we keep all existing behavior except that potentially unsafe `original_url` values will now be ignored, avoiding open redirects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
