### PR TITLE
ci: fix build even when google-fonts not available

### DIFF
--- a/app/index.css
+++ b/app/index.css
@@ -1,0 +1,6 @@
+@import 'inter-ui/inter.css';
+
+html {
+    font-family: 'Inter', sans-serif;
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,13 @@
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import NextTopLoader from 'nextjs-toploader';
 import { Flex } from '@chakra-ui/react';
 
 import ChakraUIWrapper from './ChakraUIWrapper';
 import { NavBar } from 'components/NavBar';
 
-// If loading a variable font, you don't need to specify the font weight.
-const inter = Inter({
-    subsets: ['latin'],
-    display: 'swap',
-});
+// Import global styles
+import './index.css';
 
 export const metadata: Metadata = {
     title: 'GH branch dashboard',
@@ -20,7 +16,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
     return (
-        <html lang="en" className={inter.className} suppressHydrationWarning>
+        <html lang="en" suppressHydrationWarning>
             <body>
                 <noscript>You need to enable JavaScript to run this app.</noscript>
                 <NextTopLoader />

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@next/mdx": "16.2.3",
     "@octokit/graphql-schema": "15.26.1",
     "graphql": "16.13.2",
+    "inter-ui": "4.1.1",
     "meros": "1.3.2",
     "next": "16.2.3",
     "next-themes": "0.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7825,6 +7825,7 @@ __metadata:
     eslint-plugin-storybook: "npm:10.3.5"
     globals: "npm:17.4.0"
     graphql: "npm:16.13.2"
+    inter-ui: "npm:4.1.1"
     meros: "npm:1.3.2"
     next: "npm:16.2.3"
     next-themes: "npm:0.4.6"
@@ -10004,6 +10005,13 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
+"inter-ui@npm:4.1.1":
+  version: 4.1.1
+  resolution: "inter-ui@npm:4.1.1"
+  checksum: 10c0/fb809bead520fefdef61abfca8ff7865b697e0738d2341afd4faf0539536d45638ee7812533afe413cabe765faf7a20e8e22a34c3df7693839a3acd2be44d1a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
importing inter font as a standalone font, instead of using next's google-font mechanics