### PR TITLE
ci: increase max waiting time from 10m to 20m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
       - run:
           name: deploy
           command: yarn circle:deploy
+          no_output_timeout: 20m
 workflows:
   build-and-test:
     jobs:


### PR DESCRIPTION
while deployment on vercel is waiting when queued, it could take a little more time...

```
client-debug] 2026-06-04T13:50:58.569Z Yielding a 'created' event
  Inspect     https://vercel.com/lowskys-projects/gh-dashboard-relay/.....
  Preview     https://gh-dashboard-relay-...-lowskys-projects.vercel.app
[debug] [2026-06-04T13:50:58.572Z] Spinner invoked (Building…) with a 0ms delay
[debug] [2026-06-04T13:50:58.573Z] #4 → GET https://api.vercel.com/v3/now/deployments/dpl_CzSWNvjRTSN2D2b.....
[client-debug] 2026-06-04T13:50:58.573Z Waiting for deployment to be ready...
[client-debug] 2026-06-04T13:50:58.575Z Waiting for builds and the deployment to complete...
> [debug] [2026-06-04T13:51:18.009Z] #4 ← 200 OK: sfo1::hk2g5-1780581058657-b136cf65c643 [19.44s]

Too long with no output (exceeded 10m0s): context deadline exceeded
```



see 
https://circleci.com/docs/reference/configuration-reference/#run